### PR TITLE
Set referrerpolicy attribute according to official embed code

### DIFF
--- a/feincms3/embedding.py
+++ b/feincms3/embedding.py
@@ -52,8 +52,9 @@ def embed_youtube(url):
     d = match.groupdict()
     return mark_safe(
         f'<div class="responsive-embed widescreen youtube">'
-        f'<iframe src="https://www.youtube.com/embed/{d["code"]}?rel=0"'
-        f' frameborder="0" allow="autoplay; fullscreen" allowfullscreen="">'
+        f'<iframe src="https://www.youtube.com/embed/{d["code"]}?rel=0" '
+        f'frameborder="0" allow="autoplay; fullscreen" '
+        f'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="">'
         f"</iframe>"
         f"</div>"
     )

--- a/tests/testapp/test_embedding.py
+++ b/tests/testapp/test_embedding.py
@@ -13,7 +13,8 @@ def test_youtube():
         == """\
 <div class="responsive-embed widescreen youtube"><iframe \
 src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0" frameborder="0" \
-allow="autoplay; fullscreen" allowfullscreen=""></iframe></div>"""
+allow="autoplay; fullscreen" referrerpolicy="strict-origin-when-cross-origin" \
+allowfullscreen=""></iframe></div>"""
     )
 
     assert (
@@ -21,7 +22,8 @@ allow="autoplay; fullscreen" allowfullscreen=""></iframe></div>"""
         == """\
 <div class="responsive-embed widescreen youtube"><iframe \
 src="https://www.youtube.com/embed/y7-s5ZvC_2A?rel=0" frameborder="0" \
-allow="autoplay; fullscreen" allowfullscreen=""></iframe></div>"""
+allow="autoplay; fullscreen" referrerpolicy="strict-origin-when-cross-origin" \
+allowfullscreen=""></iframe></div>"""
     )
 
     assert embed("https://www.youtube.com/watch?v=4zGnNmncJWg&feature=emb_title")
@@ -34,7 +36,10 @@ allow="autoplay; fullscreen" allowfullscreen=""></iframe></div>"""
     assert (
         embed("https://www.youtube.com/live/ljSZ0xrJjCs")
         == """\
-<div class="responsive-embed widescreen youtube"><iframe src="https://www.youtube.com/embed/ljSZ0xrJjCs?rel=0" frameborder="0" allow="autoplay; fullscreen" allowfullscreen=""></iframe></div>"""
+<div class="responsive-embed widescreen youtube"><iframe \
+src="https://www.youtube.com/embed/ljSZ0xrJjCs?rel=0" frameborder="0" \
+allow="autoplay; fullscreen" referrerpolicy="strict-origin-when-cross-origin" \
+allowfullscreen=""></iframe></div>"""
     )
 
 


### PR DESCRIPTION
@matthiask This resolves a phenomenon that occurs only for specific domains and with certain browser versions, where YouTube embeds cannot be initialized due to error 153:

<img width="1028" height="610" alt="YT153" src="https://github.com/user-attachments/assets/665549a0-a5a8-4084-a445-116f32b12905" />

I can't find any concrete indication that this is required, but official embed codes provided by YouTube include it this way and it reliably resolved the issue for me where I was able to reproduce it.